### PR TITLE
adding option to setup OnlineComponents with a name, currently not used in nlp4j-core

### DIFF
--- a/src/main/java/edu/emory/mathcs/nlp/bin/NLPTrain.java
+++ b/src/main/java/edu/emory/mathcs/nlp/bin/NLPTrain.java
@@ -21,6 +21,8 @@ import java.util.List;
 
 import org.kohsuke.args4j.Option;
 
+import com.sun.istack.internal.logging.Logger;
+
 import edu.emory.mathcs.nlp.common.util.BinUtils;
 import edu.emory.mathcs.nlp.common.util.FileUtils;
 import edu.emory.mathcs.nlp.component.dep.DEPParser;
@@ -97,6 +99,22 @@ public class NLPTrain
 				}
 			}
 
+			@Override
+			@SuppressWarnings("unchecked")
+			public OnlineComponent<N,S> createComponent(NLPMode mode, InputStream config, String name)
+			{
+				BinUtils.LOG.warn("Name not implemented for OnlineComponent. Input name-" + name + "will be ignored.");
+				switch (mode)
+				{
+				case pos: return (OnlineComponent<N,S>)new POSTagger<>(config);
+				case ner: return (OnlineComponent<N,S>)new NERTagger<>(config);
+				case dep: return (OnlineComponent<N,S>)new DEPParser<>(config);
+				case doc: return (OnlineComponent<N,S>)new DOCAnalyzer<>(config);
+				case  it: return (OnlineComponent<N,S>)new ItClassifier<>(config);
+//				case srl: return (OnlineComponent<N,S>)new SRLParser(config);
+				default : throw new IllegalArgumentException("Unsupported mode: "+mode);
+				}
+			}
 			@Override
 			@SuppressWarnings("unchecked")
 			public TSVReader<N> createTSVReader(Object2IntMap<String> map)


### PR DESCRIPTION
This change allows to construct OnlineComponents with their model's file name as a name input. Note that the implementation of createComponent in NLPTrain does not implement this and warns that is does not. This is required for compatibility beyond nlp4j-core.
